### PR TITLE
Move SDK methods logic to daoService

### DIFF
--- a/packages/solana-dao-sdk/src/constants.ts
+++ b/packages/solana-dao-sdk/src/constants.ts
@@ -13,3 +13,7 @@ export const MIN_COMMUNITY_TOKENS_TO_CREATE_WITH_ZERO_SUPPLY = 1000000;
 export const TOKEN_PROGRAM_ID = new PublicKey(
   "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
 );
+
+export const DEFAULT_PROGRAM_ID = new PublicKey(
+  "gUAedF544JeE6NYbQakQvribHykUNgaPJqcgf3UQVnY"
+);


### PR DESCRIPTION
Now, the src/index.ts and the SolanaDao class methods are all just entrypoints towards the daoService.
The daoService is the one that has all the business logic now completely.